### PR TITLE
Fix/remove redundancies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.cs]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+trim_trailing_whitespace = true
+insert_final_newline = false

--- a/Assets/SO Architecture/Collections/BaseCollection.cs
+++ b/Assets/SO Architecture/Collections/BaseCollection.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 using Type = System.Type;
 
 namespace ScriptableObjectArchitecture
@@ -32,5 +30,5 @@ namespace ScriptableObjectArchitecture
         {
             return List.Contains(obj);
         }
-} 
+	}
 }

--- a/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerator.cs
+++ b/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerator.cs
@@ -97,10 +97,7 @@ namespace ScriptableObjectArchitecture.Editor
         private static string[] _templatePaths = new string[TYPE_COUNT];
         private static string[,] _replacementStrings = null;
 
-        private static string Type { get { return _replacementStrings[0, 1]; } }
         private static string TypeName { get { return _replacementStrings[1, 1]; } }
-        private static string MenuName { get { return _replacementStrings[2, 1]; } }
-        private static string Order { get { return _replacementStrings[3, 1]; } }
 
         public static void Generate(Data data)
         {
@@ -160,5 +157,5 @@ namespace ScriptableObjectArchitecture.Editor
         {
             return input.First().ToString().ToUpper() + input.Substring(1);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Editor/Drawers/DeveloperDescriptionDrawer.cs
+++ b/Assets/SO Architecture/Editor/Drawers/DeveloperDescriptionDrawer.cs
@@ -1,8 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEditor;
-using UnityEditor.AnimatedValues;
 
 namespace ScriptableObjectArchitecture.Editor
 {
@@ -103,5 +100,5 @@ namespace ScriptableObjectArchitecture.Editor
                 TextAreaStyle.normal = EditorStyles.label.normal;
             }
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Editor/Drawers/GenericPropertyDrawer.cs
+++ b/Assets/SO Architecture/Editor/Drawers/GenericPropertyDrawer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
 
 namespace ScriptableObjectArchitecture.Editor
@@ -32,5 +30,5 @@ namespace ScriptableObjectArchitecture.Editor
                 EditorGUILayout.LabelField(errorLabel);
             }
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Editor/Inspectors/BaseGameEventEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/BaseGameEventEditor.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEditor;
-using UnityEngine;
 
 namespace ScriptableObjectArchitecture.Editor
 {
@@ -25,5 +24,5 @@ namespace ScriptableObjectArchitecture.Editor
 
             EditorGUILayout.PropertyField(DeveloperDescription);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Editor/Inspectors/BaseVariableEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/BaseVariableEditor.cs
@@ -1,7 +1,4 @@
-﻿using System.Reflection;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEditor;
 using UnityEditor.AnimatedValues;
 
@@ -95,5 +92,5 @@ namespace ScriptableObjectArchitecture.Editor
         {
             EditorGUILayout.PropertyField(_developerDescription);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Editor/Inspectors/CollectionEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/CollectionEditor.cs
@@ -1,7 +1,5 @@
-﻿using System.Reflection;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
-using Type = System.Type;
 using ReorderableList = UnityEditorInternal.ReorderableList;
 
 namespace ScriptableObjectArchitecture.Editor
@@ -66,5 +64,5 @@ namespace ScriptableObjectArchitecture.Editor
         {
             Target.List.RemoveAt(list.index);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Editor/Inspectors/StackTrace.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/StackTrace.cs
@@ -32,7 +32,6 @@ namespace ScriptableObjectArchitecture.Editor
         private const float CLEAR_LEFT_PADDING = 6;
         private const float CLEAR_WIDTH = 45;
         private const float COLLAPSE_WIDTH = 55;
-        private const float PADDING = 30;
         private const float LINE_HEIGHT = 18;
 
         private StackTraceEntry _selectedTrace;

--- a/Assets/SO Architecture/Editor/Inspectors/StackTrace.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/StackTrace.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using UnityEditor;
 using UnityEditor.AnimatedValues;
 using UnityEngine;
@@ -259,5 +258,5 @@ namespace ScriptableObjectArchitecture.Editor
             public static GUIStyle OddBackground;
             public static GUIStyle MessageStyle;
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Editor/Inspectors/TypedGameEventEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/TypedGameEventEditor.cs
@@ -8,8 +8,6 @@ namespace ScriptableObjectArchitecture.Editor
     [CustomEditor(typeof(GameEventBase<>), true)]
     public class TypedGameEventEditor : BaseGameEventEditor
     {
-        private Type GenericType { get { return target.GetType().BaseType.GetGenericArguments()[0]; } }
-
         private MethodInfo _raiseMethod;
 
         protected override void OnEnable()
@@ -42,5 +40,5 @@ namespace ScriptableObjectArchitecture.Editor
         {
             _raiseMethod.Invoke(target, new object[1] { value });
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Editor/Inspectors/TypesGameEventListenerEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/TypesGameEventListenerEditor.cs
@@ -8,8 +8,6 @@ namespace ScriptableObjectArchitecture.Editor
     [CustomEditor(typeof(BaseGameEventListener<,,>), true)]
     public class TypesGameEventListenerEditor : BaseGameEventListenerEditor
     {
-        private System.Type GenericType { get { return target.GetType().BaseType.GetGenericArguments()[0]; } }
-
         private MethodInfo _raiseMethod;
 
         protected override void OnEnable()
@@ -42,5 +40,5 @@ namespace ScriptableObjectArchitecture.Editor
         {
             _raiseMethod.Invoke(target, new object[1] { value });
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Editor/SOArchitecture_EditorUtility.cs
+++ b/Assets/SO Architecture/Editor/SOArchitecture_EditorUtility.cs
@@ -1,8 +1,5 @@
-﻿using System.IO;
-using System.Reflection;
-using System.Collections;
+﻿using System.Reflection;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.Callbacks;
@@ -113,5 +110,5 @@ namespace ScriptableObjectArchitecture.Editor
                 }
             }
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Editor/SerializedPropertyHelper.cs
+++ b/Assets/SO Architecture/Editor/SerializedPropertyHelper.cs
@@ -1,5 +1,4 @@
-﻿using UnityEngine;
- using System.Collections;
+﻿using System.Collections;
  using UnityEditor;
  using System.Linq;
  using System;
@@ -54,5 +53,5 @@ namespace ScriptableObjectArchitecture.Editor
                 enm.MoveNext();
             return enm.Current;
         }
-    }  
+    }
 }

--- a/Assets/SO Architecture/Events/Game Events/GameEventStackTrace.cs
+++ b/Assets/SO Architecture/Events/Game Events/GameEventStackTrace.cs
@@ -5,7 +5,6 @@ namespace ScriptableObjectArchitecture
 {
     public class StackTraceEntry : IEquatable<StackTraceEntry>
     {
-        private StackTraceEntry() { }
         private StackTraceEntry(string trace)
         {
             _id = UnityEngine.Random.Range(int.MinValue, int.MaxValue);
@@ -79,5 +78,5 @@ namespace ScriptableObjectArchitecture
         {
             return trace.ToString();
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Examples/Scripts/CollectionCountDisplayer.cs
+++ b/Assets/SO Architecture/Examples/Scripts/CollectionCountDisplayer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UI;
 
 namespace ScriptableObjectArchitecture.Examples
@@ -18,5 +16,5 @@ namespace ScriptableObjectArchitecture.Examples
         {
             _textTarget.text = string.Format(_textFormat, _setTarget.Count);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Examples/Scripts/DamageDealer.cs
+++ b/Assets/SO Architecture/Examples/Scripts/DamageDealer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace ScriptableObjectArchitecture.Examples
 {
@@ -20,5 +18,5 @@ namespace ScriptableObjectArchitecture.Examples
         {
             target.Health.Value -= _damageAmount.Value;
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Examples/Scripts/DamageDealerWithEvent.cs
+++ b/Assets/SO Architecture/Examples/Scripts/DamageDealerWithEvent.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace ScriptableObjectArchitecture.Examples
 {
@@ -15,5 +13,5 @@ namespace ScriptableObjectArchitecture.Examples
 
             _onDamagedEvent.Raise();
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Examples/Scripts/Disabler.cs
+++ b/Assets/SO Architecture/Examples/Scripts/Disabler.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace ScriptableObjectArchitecture.Examples
 {
@@ -19,5 +17,5 @@ namespace ScriptableObjectArchitecture.Examples
                 objToDisable.SetActive(false);
             }
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Examples/Scripts/ImageFillSetter.cs
+++ b/Assets/SO Architecture/Examples/Scripts/ImageFillSetter.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UI;
 
 namespace ScriptableObjectArchitecture.Examples
@@ -19,5 +17,5 @@ namespace ScriptableObjectArchitecture.Examples
             _imageTarget.fillAmount = Mathf.Clamp01(_variable.Value / _maxValue.Value);
         }
 
-    } 
+    }
 }

--- a/Assets/SO Architecture/Examples/Scripts/KeyboardMover.cs
+++ b/Assets/SO Architecture/Examples/Scripts/KeyboardMover.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace ScriptableObjectArchitecture.Examples
 {
@@ -23,5 +21,5 @@ namespace ScriptableObjectArchitecture.Examples
             if (Input.GetKey(KeyCode.A) || Input.GetKey(KeyCode.LeftArrow))
                 transform.position += Vector3.left * _moveSpeed.Value;
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Examples/Scripts/ObjectAdder.cs
+++ b/Assets/SO Architecture/Examples/Scripts/ObjectAdder.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace ScriptableObjectArchitecture.Examples
 {
@@ -17,5 +15,5 @@ namespace ScriptableObjectArchitecture.Examples
         {
             _targetCollection.Remove(gameObject);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Examples/Scripts/UnitHealth.cs
+++ b/Assets/SO Architecture/Examples/Scripts/UnitHealth.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace ScriptableObjectArchitecture.Examples
 {
@@ -18,5 +16,5 @@ namespace ScriptableObjectArchitecture.Examples
             if (_resetOnStartup)
                 Health.Value = _startingHealth.Value;
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Utility/DeveloperDescription.cs
+++ b/Assets/SO Architecture/Utility/DeveloperDescription.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace ScriptableObjectArchitecture
@@ -52,5 +50,5 @@ namespace ScriptableObjectArchitecture
         {
             return _value;
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Utility/SOArchitecture_Settings.cs
+++ b/Assets/SO Architecture/Utility/SOArchitecture_Settings.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace ScriptableObjectArchitecture
 {
@@ -63,5 +61,5 @@ namespace ScriptableObjectArchitecture
         private bool _codeGenerationAllowOverwrite = false;
         [SerializeField]
         private int _defualtCreateAssetMenuOrder = 120;
-    } 
+    }
 }

--- a/Assets/SO Architecture/Variables/Clamped/ByteClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/ByteClampedVariable.cs
@@ -6,7 +6,7 @@ namespace ScriptableObjectArchitecture
         fileName = "ByteClampedVariable.asset",
         menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "byte",
         order = 120)]
-    public class ByteClampedVariable : ByteVariable, IClampedVariable<byte, ByteVariable, ByteReference>
+    public class ByteClampedVariable : ByteVariable, IClampedVariable<byte, ByteReference>
     {
         public ByteReference MinValue { get { return _minClampedValue; } }
         public ByteReference MaxValue { get { return _maxClampedValue; } }
@@ -39,5 +39,5 @@ namespace ScriptableObjectArchitecture
         {
             return ClampValue(value);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Variables/Clamped/DoubleClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/DoubleClampedVariable.cs
@@ -6,7 +6,7 @@ namespace ScriptableObjectArchitecture
         fileName = "DoubleClampedVariable.asset",
         menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "double",
         order = 120)]
-    public class DoubleClampedVariable : DoubleVariable, IClampedVariable<double, DoubleVariable, DoubleReference>
+    public class DoubleClampedVariable : DoubleVariable, IClampedVariable<double, DoubleReference>
     {
         public DoubleReference MinValue { get { return _minClampedValue; } }
         public DoubleReference MaxValue { get { return _maxClampedValue; } }
@@ -39,5 +39,5 @@ namespace ScriptableObjectArchitecture
         {
             return ClampValue(value);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Variables/Clamped/FloatClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/FloatClampedVariable.cs
@@ -6,7 +6,7 @@ namespace ScriptableObjectArchitecture
         fileName = "FloatClampedVariable.asset",
         menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "float",
         order = SOArchitecture_Utility.ASSET_MENU_ORDER_CLAMPED_VARIABLES + 0)]
-    public class FloatClampedVariable : FloatVariable, IClampedVariable<float, FloatVariable, FloatReference>
+    public class FloatClampedVariable : FloatVariable, IClampedVariable<float, FloatReference>
     {
         public FloatReference MinValue { get { return _minClampedValue; } }
         public FloatReference MaxValue { get { return _maxClampedValue; } }
@@ -39,5 +39,5 @@ namespace ScriptableObjectArchitecture
         {
             return ClampValue(value);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Variables/Clamped/IClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/IClampedVariable.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
-namespace ScriptableObjectArchitecture
+﻿namespace ScriptableObjectArchitecture
 {
     public interface IClampedVariable { }
     public interface IClampedVariable<TType, TVariable, TReference> : IClampedVariable
@@ -11,5 +7,5 @@ namespace ScriptableObjectArchitecture
         TReference MaxValue { get; }
 
         TType ClampValue(TType value);
-    } 
+    }
 }

--- a/Assets/SO Architecture/Variables/Clamped/IClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/IClampedVariable.cs
@@ -1,7 +1,7 @@
 ﻿namespace ScriptableObjectArchitecture
 {
     public interface IClampedVariable { }
-    public interface IClampedVariable<TType, TVariable, TReference> : IClampedVariable
+    public interface IClampedVariable<TType, TReference> : IClampedVariable
     {
         TReference MinValue { get; }
         TReference MaxValue { get; }

--- a/Assets/SO Architecture/Variables/Clamped/IntClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/IntClampedVariable.cs
@@ -6,7 +6,7 @@ namespace ScriptableObjectArchitecture
         fileName = "IntClampedVariable.asset",
         menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "int",
         order = 120)]
-    public class IntClampedVariable : IntVariable, IClampedVariable<int, IntVariable, IntReference>
+    public class IntClampedVariable : IntVariable, IClampedVariable<int, IntReference>
     {
         public IntReference MinValue { get { return _minClampedValue; } }
         public IntReference MaxValue { get { return _maxClampedValue; } }
@@ -39,5 +39,5 @@ namespace ScriptableObjectArchitecture
         {
             return ClampValue(value);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Variables/Clamped/LongClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/LongClampedVariable.cs
@@ -6,7 +6,7 @@ namespace ScriptableObjectArchitecture
         fileName = "LongClampedVariable.asset",
         menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "long",
         order = 120)]
-    public class LongClampedVariable : LongVariable, IClampedVariable<long, LongVariable, LongReference>
+    public class LongClampedVariable : LongVariable, IClampedVariable<long, LongReference>
     {
         public LongReference MinValue { get { return _minClampedValue; } }
         public LongReference MaxValue { get { return _maxClampedValue; } }
@@ -39,5 +39,5 @@ namespace ScriptableObjectArchitecture
         {
             return ClampValue(value);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Variables/Clamped/SByteClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/SByteClampedVariable.cs
@@ -6,7 +6,7 @@ namespace ScriptableObjectArchitecture
         fileName = "SbyteClampedVariable.asset",
         menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "sbyte",
         order = 120)]
-    public class SByteClampedVariable : SByteVariable, IClampedVariable<sbyte, SByteVariable, SByteVariable>
+    public class SByteClampedVariable : SByteVariable, IClampedVariable<sbyte, SByteVariable>
     {
         public SByteVariable MinValue { get { return _minClampedValue; } }
         public SByteVariable MaxValue { get { return _maxClampedValue; } }
@@ -39,5 +39,5 @@ namespace ScriptableObjectArchitecture
         {
             return ClampValue(value);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Variables/Clamped/ShortClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/ShortClampedVariable.cs
@@ -6,7 +6,7 @@ namespace ScriptableObjectArchitecture
         fileName = "ShortClampedVariable.asset",
         menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "short",
         order = 120)]
-    public class ShortClampedVariable : ShortVariable, IClampedVariable<short, ShortVariable, ShortReference>
+    public class ShortClampedVariable : ShortVariable, IClampedVariable<short, ShortReference>
     {
         public ShortReference MinValue { get { return _minClampedValue; } }
         public ShortReference MaxValue { get { return _maxClampedValue; } }
@@ -39,5 +39,5 @@ namespace ScriptableObjectArchitecture
         {
             return ClampValue(value);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Variables/Clamped/UIntClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/UIntClampedVariable.cs
@@ -6,7 +6,7 @@ namespace ScriptableObjectArchitecture
         fileName = "UintClampedVariable.asset",
         menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "uint",
         order = 120)]
-    public class UintClampedVariable : UIntVariable, IClampedVariable<uint, UIntVariable, UIntVariable>
+    public class UintClampedVariable : UIntVariable, IClampedVariable<uint, UIntVariable>
     {
         public UIntVariable MinValue { get { return _minClampedValue; } }
         public UIntVariable MaxValue { get { return _maxClampedValue; } }
@@ -39,5 +39,5 @@ namespace ScriptableObjectArchitecture
         {
             return ClampValue(value);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Variables/Clamped/ULongClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/ULongClampedVariable.cs
@@ -6,7 +6,7 @@ namespace ScriptableObjectArchitecture
         fileName = "UlongClampedVariable.asset",
         menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "ulong",
         order = 120)]
-    public class UlongClampedVariable : ULongVariable, IClampedVariable<ulong, ULongVariable, ULongVariable>
+    public class UlongClampedVariable : ULongVariable, IClampedVariable<ulong, ULongVariable>
     {
         public ULongVariable MinValue { get { return _minClampedValue; } }
         public ULongVariable MaxValue { get { return _maxClampedValue; } }
@@ -39,5 +39,5 @@ namespace ScriptableObjectArchitecture
         {
             return ClampValue(value);
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Variables/Clamped/UShortClampedVariable.cs
+++ b/Assets/SO Architecture/Variables/Clamped/UShortClampedVariable.cs
@@ -6,7 +6,7 @@ namespace ScriptableObjectArchitecture
         fileName = "UshortClampedVariable.asset",
         menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "ushort",
         order = 120)]
-    public class UshortClampedVariable : UShortVariable, IClampedVariable<ushort, UShortVariable, UShortVariable>
+    public class UshortClampedVariable : UShortVariable, IClampedVariable<ushort, UShortVariable>
     {
         public UShortVariable MinValue { get { return _minClampedValue; } }
         public UShortVariable MaxValue { get { return _maxClampedValue; } }
@@ -39,5 +39,5 @@ namespace ScriptableObjectArchitecture
         {
             return ClampValue(value);
         }
-    } 
+    }
 }


### PR DESCRIPTION
### Summary
This PR looks to improve some small, low-hanging fruit for code quality issues by:
* Removing unused namespaces.
* Removed unused members that are not used and private 
* Removed unused generic parameter of IClampedVariable (not used in interface definition)

In addition I created a .editorconfig based on the existing code style that should make it easier to contribute by adhering to the existing conventions for end-of-line characters (i.e, Windows CRLF), tab size and character used (spaces instead of tab character in this case), not inserting a new-line at the end of the file, and trimming whitespace from the end of lines. Almost all text-editor based IDEs like visual studio code, sublime, etc.... will pick this up automatically if opening the repo folder while others like Visual Studio will have to add the file to their solution manually as Unity will recreate the solution when opening for the first time and blow away any manually added previous files.

### Testing
Removing the generic parameter of IClampedVariable will cause a compilation error for any implementing classes in downstream user projects, otherwise there should not be any functional changes based on this PR. Just looking to clean up a few things before making more substantive PRs! :)