### PR TITLE
Fix/add namepace to code templates

### DIFF
--- a/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerationWindow.cs
+++ b/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerationWindow.cs
@@ -25,7 +25,7 @@ namespace ScriptableObjectArchitecture.Editor
          * 7        X        X
          */
 
-        private bool[,] _dependencyGraph = new bool[SO_CodeGenerator.TYPE_COUNT, SO_CodeGenerator.TYPE_COUNT]
+        private readonly bool[,] _dependencyGraph = new bool[SO_CodeGenerator.TYPE_COUNT, SO_CodeGenerator.TYPE_COUNT]
         {
         { false, true, false, false, true, false, false },
         { false, false, true, false, false, false, false },
@@ -36,8 +36,8 @@ namespace ScriptableObjectArchitecture.Editor
         { false, false, true, false, false, true, false },
         };
 
-        private bool[] _states = new bool[SO_CodeGenerator.TYPE_COUNT];
-        private string[] _names = new string[SO_CodeGenerator.TYPE_COUNT]
+        private readonly bool[] _states = new bool[SO_CodeGenerator.TYPE_COUNT];
+        private readonly string[] _names = new string[SO_CodeGenerator.TYPE_COUNT]
         {
         "Event Listener",
         "Game Event",
@@ -48,7 +48,7 @@ namespace ScriptableObjectArchitecture.Editor
         "Clamped Variable",
         };
 
-        private bool[] _menuRequirement = new bool[SO_CodeGenerator.TYPE_COUNT]
+        private readonly bool[] _menuRequirement = new bool[SO_CodeGenerator.TYPE_COUNT]
         {
         false, true, false, true, false, true, true
         };
@@ -64,7 +64,7 @@ namespace ScriptableObjectArchitecture.Editor
         [MenuItem("Window/SO Code Generation")]
         private static void ShowWindow()
         {
-            EditorWindow.GetWindow(typeof(SO_CodeGenerationWindow), true, "SO Code Generation");
+            GetWindow(typeof(SO_CodeGenerationWindow), true, "SO Code Generation");
         }
         private void OnEnable()
         {
@@ -176,5 +176,5 @@ namespace ScriptableObjectArchitecture.Editor
 
             return false;
         }
-    } 
+    }
 }

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/ClampedVariableTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/ClampedVariableTemplate
@@ -1,40 +1,43 @@
 using UnityEngine;
 
-[CreateAssetMenu(
-    fileName = "$TYPE_NAME$ClampedVariable.asset",
-    menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "$MENU_NAME$",
-    order = $ORDER$)]
-public class $TYPE_NAME$ClampedVariable : $TYPE_NAME$Variable, IClampedVariable<$TYPE$, $TYPE_NAME$Variable, $TYPE_NAME$Reference>
+namespace ScriptableObjectArchitecture
 {
-    public $TYPE_NAME$Reference MinValue { get { return _minClampedValue; } }
-    public $TYPE_NAME$Reference MaxValue { get { return _maxClampedValue; } }
+    [CreateAssetMenu(
+        fileName = "$TYPE_NAME$ClampedVariable.asset",
+        menuName = SOArchitecture_Utility.VARIABLE_CLAMPED_SUBMENU + "$MENU_NAME$",
+        order = $ORDER$)]
+    public class $TYPE_NAME$ClampedVariable : $TYPE_NAME$Variable, IClampedVariable<$TYPE$, $TYPE_NAME$Reference>
+    {
+        public $TYPE_NAME$Reference MinValue { get { return _minClampedValue; } }
+        public $TYPE_NAME$Reference MaxValue { get { return _maxClampedValue; } }
 
-    [SerializeField]
-    private $TYPE_NAME$Reference _minClampedValue;
-    [SerializeField]
-    private $TYPE_NAME$Reference _maxClampedValue;
+        [SerializeField]
+        private $TYPE_NAME$Reference _minClampedValue;
+        [SerializeField]
+        private $TYPE_NAME$Reference _maxClampedValue;
 
-    public virtual $TYPE$ ClampValue($TYPE$ value)
-    {
-        if (value.CompareTo(MinValue.Value) < 0)
+        public virtual $TYPE$ ClampValue($TYPE$ value)
         {
-            return MinValue.Value;
-        }            
-        else if (value.CompareTo(MaxValue.Value) > 0)
+            if (value.CompareTo(MinValue.Value) < 0)
+            {
+                return MinValue.Value;
+            }            
+            else if (value.CompareTo(MaxValue.Value) > 0)
+            {
+                return MaxValue.Value;
+            }            
+            else
+            {
+                return value;
+            }            
+        }
+        public override $TYPE$ SetValue(BaseVariable<$TYPE$> value)
         {
-            return MaxValue.Value;
-        }            
-        else
+            return ClampValue(value.Value);
+        }
+        public override $TYPE$ SetValue($TYPE$ value)
         {
-            return value;
-        }            
-    }
-    public override $TYPE$ SetValue(BaseVariable<$TYPE$> value)
-    {
-        return ClampValue(value.Value);
-    }
-    public override $TYPE$ SetValue($TYPE$ value)
-    {
-        return ClampValue(value);
+            return ClampValue(value);
+        }
     }
 }

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/CollectionTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/CollectionTemplate
@@ -1,9 +1,12 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(
-    fileName = "$TYPE_NAME$Collection.asset",
-    menuName = SOArchitecture_Utility.COLLECTION_SUBMENU + "$MENU_NAME$",
-    order = $ORDER$)]
-public class $TYPE_NAME$Collection : Collection<$TYPE$>
+namespace ScriptableObjectArchitecture
 {
+	[CreateAssetMenu(
+	    fileName = "$TYPE_NAME$Collection.asset",
+	    menuName = SOArchitecture_Utility.COLLECTION_SUBMENU + "$MENU_NAME$",
+	    order = $ORDER$)]
+	public class $TYPE_NAME$Collection : Collection<$TYPE$>
+	{
+	}
 }

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventListenerTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventListenerTemplate
@@ -1,5 +1,8 @@
 ﻿using UnityEngine;
 
-public sealed class $TYPE_NAME$GameEventListener : BaseGameEventListener<$TYPE$, $TYPE_NAME$GameEvent, $TYPE_NAME$UnityEvent>
+namespace ScriptableObjectArchitecture
 {
+	public sealed class $TYPE_NAME$GameEventListener : BaseGameEventListener<$TYPE$, $TYPE_NAME$GameEvent, $TYPE_NAME$UnityEvent>
+	{
+	}
 }

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventTemplate
@@ -1,10 +1,13 @@
 ﻿using UnityEngine;
 
-[System.Serializable]
-[CreateAssetMenu(
-    fileName = "$TYPE_NAME$GameEvent.asset",
-    menuName = SOArchitecture_Utility.GAME_EVENT + "$MENU_NAME$",
-    order = $ORDER$)]
-public sealed class $TYPE_NAME$GameEvent : GameEventBase<$TYPE$>
+namespace ScriptableObjectArchitecture
 {
+	[System.Serializable]
+	[CreateAssetMenu(
+	    fileName = "$TYPE_NAME$GameEvent.asset",
+	    menuName = SOArchitecture_Utility.GAME_EVENT + "$MENU_NAME$",
+	    order = $ORDER$)]
+	public sealed class $TYPE_NAME$GameEvent : GameEventBase<$TYPE$>
+	{
+	}
 }

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/ReferenceTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/ReferenceTemplate
@@ -1,8 +1,11 @@
 ﻿using UnityEngine;
 
-[System.Serializable]
-public sealed class $TYPE_NAME$Reference : BaseReference<$TYPE$, $TYPE_NAME$Variable>
+namespace ScriptableObjectArchitecture
 {
-    public $TYPE_NAME$Reference() : base() { }
-    public $TYPE_NAME$Reference($TYPE$ value) : base(value) { }
+	[System.Serializable]
+	public sealed class $TYPE_NAME$Reference : BaseReference<$TYPE$, $TYPE_NAME$Variable>
+	{
+	    public $TYPE_NAME$Reference() : base() { }
+	    public $TYPE_NAME$Reference($TYPE$ value) : base(value) { }
+	}
 }

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/UnityEventTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/UnityEventTemplate
@@ -1,7 +1,10 @@
 ﻿using UnityEngine;
 using UnityEngine.Events;
 
-[System.Serializable]
-public sealed class $TYPE_NAME$UnityEvent : UnityEvent<$TYPE$>
+namespace ScriptableObjectArchitecture
 {
+	[System.Serializable]
+	public sealed class $TYPE_NAME$UnityEvent : UnityEvent<$TYPE$>
+	{
+	}
 }

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/VariableTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/VariableTemplate
@@ -1,9 +1,12 @@
 ﻿using UnityEngine;
 
-[CreateAssetMenu(
-    fileName = "$TYPE_NAME$Variable.asset",
-    menuName = SOArchitecture_Utility.VARIABLE_SUBMENU + "$MENU_NAME$",
-    order = $ORDER$)]
-public class $TYPE_NAME$Variable : BaseVariable<$TYPE$>
+namespace ScriptableObjectArchitecture
 {
+	[CreateAssetMenu(
+	    fileName = "$TYPE_NAME$Variable.asset",
+	    menuName = SOArchitecture_Utility.VARIABLE_SUBMENU + "$MENU_NAME$",
+	    order = $ORDER$)]
+	public class $TYPE_NAME$Variable : BaseVariable<$TYPE$>
+	{
+	}
 }


### PR DESCRIPTION
### Summary
This PR updates the templates used for code generation to include the `ScriptableObjectArchitecture` namespace to help reduce the number of immediate errors when generating code via this way. It also fixes a small bug where the template for `ClampedVariable` still included a second generic argument for a Variable type (recently removed as unused).

### Testing
To test this, try generating code for all supported types for an arbitrary class without a namespace like so:

```
[Serializable]
public  class Foo
{
}
```

When code is generated, this should result in fewer less errors as all of the `ScriptableObjectArchitecture` types will now be in the correct namespace and not require additional using statements or manual efforts to correct this.

### Changes
**Modified code generation window**
* Marked inline initialized arrays as readonly
* Removed redundant call to static EditorWindow method as SO_CodeGenerationWindow is of type EditorWindow; simplified method call.

**Updated code generation templates**
* Updated code generation templates to include ScriptableObjectArchitecture namespace
* Updated ClampedVariable template to not include the second generic type value for IClampedVariable since that no longer exists.