### PR TITLE
Modified GameEventListeners to include AddComponent

### DIFF
--- a/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventListenerTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventListenerTemplate
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 
+[AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "$TYPE$")]
 public sealed class $TYPE_NAME$GameEventListener : BaseGameEventListener<$TYPE$, $TYPE_NAME$GameEvent, $TYPE_NAME$UnityEvent>
 {
 }

--- a/Assets/SO Architecture/Events/Listeners/BoolGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/BoolGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "bool")]
     public sealed class BoolGameEventListener : BaseGameEventListener<bool, BoolGameEvent, BoolUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/ByteGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/ByteGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "byte")]
     public sealed class ByteGameEventListener : BaseGameEventListener<byte, ByteGameEvent, ByteUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/CharGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/CharGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "char")]
     public sealed class CharGameEventListener : BaseGameEventListener<char, CharGameEvent, CharUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/DoubleGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/DoubleGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "double")]
     public sealed class DoubleGameEventListener : BaseGameEventListener<double, DoubleGameEvent, DoubleUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/FloatGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/FloatGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "float")]
     public sealed class FloatGameEventListener : BaseGameEventListener<float, FloatGameEvent, FloatUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/GameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/GameEventListener.cs
@@ -3,8 +3,9 @@ using UnityEngine.Events;
 
 namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "GameEvent")]
     [ExecuteInEditMode]
     public sealed class GameEventListener : BaseGameEventListener<GameEventBase, UnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/GameObjectGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/GameObjectGameEventListener.cs
@@ -2,7 +2,8 @@ using UnityEngine;
 
 namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "GameObject")]
     public sealed class GameObjectGameEventListener : BaseGameEventListener<GameObject, GameObjectGameEvent, GameObjectUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/IntGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/IntGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "int")]
     public sealed class IntGameEventListener : BaseGameEventListener<int, IntGameEvent, IntUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/LongGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/LongGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "long")]
     public sealed class LongGameEventListener : BaseGameEventListener<long, LongGameEvent, LongUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/ObjectGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/ObjectGameEventListener.cs
@@ -2,7 +2,8 @@
 
 namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "Object")]
     public class ObjectGameEventListener : BaseGameEventListener<Object, ObjectGameEvent, ObjectUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/QuaternionGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/QuaternionGameEventListener.cs
@@ -2,7 +2,8 @@ using UnityEngine;
 
 namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "Quaternion")]
     public sealed class QuaternionGameEventListener : BaseGameEventListener<Quaternion, QuaternionGameEvent, QuaternionUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/SByteGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/SByteGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "sbyte")]
     public sealed class SByteGameEventListener : BaseGameEventListener<sbyte, SByteGameEvent, SByteUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/ShortGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/ShortGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "short")]
     public sealed class ShortGameEventListener : BaseGameEventListener<short, ShortGameEvent, ShortUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/StringGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/StringGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "string")]
     public sealed class StringGameEventListener : BaseGameEventListener<string, StringGameEvent, StringUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/UIntGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/UIntGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "uint")]
     public sealed class UIntGameEventListener : BaseGameEventListener<uint, UIntGameEvent, UIntUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/ULongGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/ULongGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "ulong")]
     public sealed class ULongGameEventListener : BaseGameEventListener<ulong, ULongGameEvent, ULongUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/UShortGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/UShortGameEventListener.cs
@@ -1,6 +1,9 @@
-﻿namespace ScriptableObjectArchitecture
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "ushort")]
     public sealed class UShortGameEventListener : BaseGameEventListener<ushort, UShortGameEvent, UShortUnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/Vector2GameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/Vector2GameEventListener.cs
@@ -2,7 +2,8 @@ using UnityEngine;
 
 namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "Vector2")]
     public sealed class Vector2GameEventListener : BaseGameEventListener<Vector2, Vector2GameEvent, Vector2UnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/Vector3GameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/Vector3GameEventListener.cs
@@ -2,7 +2,8 @@ using UnityEngine;
 
 namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "Vector3")]
     public sealed class Vector3GameEventListener : BaseGameEventListener<Vector3, Vector3GameEvent, Vector3UnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Events/Listeners/Vector4GameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/Vector4GameEventListener.cs
@@ -2,7 +2,8 @@ using UnityEngine;
 
 namespace ScriptableObjectArchitecture
 {
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "Vector4")]
     public sealed class Vector4GameEventListener : BaseGameEventListener<Vector4, Vector4GameEvent, Vector4UnityEvent>
     {
-    } 
+    }
 }

--- a/Assets/SO Architecture/Utility/SOArchitecture_Utility.cs
+++ b/Assets/SO Architecture/Utility/SOArchitecture_Utility.cs
@@ -15,5 +15,9 @@
         public const string ADVANCED_GAME_EVENT = GAME_EVENT + "Advanced/";
         public const string ADVANCED_VARIABLE_SUBMENU = VARIABLE_SUBMENU + "Advanced/";
         public const string ADVANCED_VARIABLE_COLLECTION = COLLECTION_SUBMENU + "Advanced/";
-    } 
+
+        // Add Component Menus
+        public const string ADD_COMPONENT_ROOT_MENU = "SOArchitecture/";
+        public const string EVENT_LISTENER_SUBMENU = ADD_COMPONENT_ROOT_MENU + "Event Listeners/";
+    }
 }


### PR DESCRIPTION
### Summary
This PR aims to add a small quality of life improvement by organizing the game event listener types into a more easily searchable menu when using `[AddComponent]` on a GameObject inspector. It also updates the template for game event listeners to include the `[AddComponent]` attribute so future classes can automatically gain the benefit of this change.

![AddComponentMenusForGameEventListeners](https://user-images.githubusercontent.com/1663648/56342300-e5927180-61b7-11e9-96c8-68a3cc71daad.gif)

### Testing
I would create a `GameObject` in the scene and try navigating the add component menu to ensure that all game event listener types are present and that the menu item name for each one is consistent for casing/spelling with that same type used in other menus such as for Variables or Events.

There will also likely be a small conflict with https://github.com/DanielEverland/ScriptableObject-Architecture/pull/58 as both PRs modify this template, but should be easy to resolve.

### Changes
**Modified GameEventListeners for AddComponent**
* Modified SOArchitecture_Utility to include new constants for [AddComponent] menu structure for library and event listeners (currently only component type in library).
* Modified code generation template to include [AddComponent] setup.
* Modified all closed GameEventListener types to include [AddComponent] attribute with consistent menu names as used elsewhere for asset creation (case for menu item matches type name case).