### PR TITLE
Fix collection drawer render order bug

### DIFF
--- a/Assets/PR Test Content.meta
+++ b/Assets/PR Test Content.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 918bbf3c68c7e5a418c8cfe26c10b0b2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/GameObjectCollection.asset
+++ b/Assets/PR Test Content/GameObjectCollection.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 156f4052644faf645bba864aa1fd4e16, type: 3}
+  m_Name: GameObjectCollection
+  m_EditorClassIdentifier: 
+  DeveloperDescription:
+    _value: 
+  _list: []

--- a/Assets/PR Test Content/GameObjectCollection.asset.meta
+++ b/Assets/PR Test Content/GameObjectCollection.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b12e90b77abc2ee47b5ca8df470aae49
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/IntCollection.asset
+++ b/Assets/PR Test Content/IntCollection.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dba6f7bc1140ccb439039e265858770b, type: 3}
+  m_Name: IntCollection
+  m_EditorClassIdentifier: 
+  DeveloperDescription:
+    _value: 
+  _list: 

--- a/Assets/PR Test Content/IntCollection.asset.meta
+++ b/Assets/PR Test Content/IntCollection.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d0bba468369082947bc2040751023cdb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SO Architecture/Editor/Drawers/GenericPropertyDrawer.cs
+++ b/Assets/SO Architecture/Editor/Drawers/GenericPropertyDrawer.cs
@@ -5,7 +5,47 @@ namespace ScriptableObjectArchitecture.Editor
 {
     public static class GenericPropertyDrawer
     {
-        public static void DrawPropertyDrawer(System.Type type, SerializedProperty property, GUIContent errorLabel)
+        /// <summary>
+        /// Draws a property drawer using the <see cref="EditorGUI"/> methods and the area the drawer is drawn
+        /// in is determined by the passed <see cref="Rect"/> <paramref name="rect"/>.
+        /// </summary>
+        /// <param name="rect"></param>
+        /// <param name="type"></param>
+        /// <param name="property"></param>
+        /// <param name="errorLabel"></param>
+        public static void DrawPropertyDrawer(Rect rect, System.Type type, SerializedProperty property, GUIContent errorLabel)
+        {
+            if (SOArchitecture_EditorUtility.HasPropertyDrawer(type) || typeof(Object).IsAssignableFrom(type) || type.IsEnum)
+            {
+                //Unity doesn't like it when you have scene objects on assets,
+                //so we do some magic to display it anyway
+                if (typeof(Object).IsAssignableFrom(type)
+                    && !EditorUtility.IsPersistent(property.objectReferenceValue)
+                    && property.objectReferenceValue != null)
+                {
+                    using (new EditorGUI.DisabledGroupScope(true))
+                    {
+                        EditorGUI.ObjectField(rect, new GUIContent("Value"), property.objectReferenceValue, type, false);
+                    }
+                }
+                else
+                {
+                    EditorGUI.PropertyField(rect, property);
+                }
+            }
+            else
+            {
+                EditorGUI.LabelField(rect, errorLabel);
+            }
+        }
+
+        /// <summary>
+        /// Draws a property drawer using the <see cref="EditorGUILayout"/> methods.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="property"></param>
+        /// <param name="errorLabel"></param>
+        public static void DrawPropertyDrawerLayout(System.Type type, SerializedProperty property, GUIContent errorLabel)
         {
             if (SOArchitecture_EditorUtility.HasPropertyDrawer(type) || typeof(Object).IsAssignableFrom(type) || type.IsEnum)
             {

--- a/Assets/SO Architecture/Editor/Inspectors/BaseVariableEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/BaseVariableEditor.cs
@@ -50,7 +50,7 @@ namespace ScriptableObjectArchitecture.Editor
             using (var scope = new EditorGUI.ChangeCheckScope())
             {
                 string content = "Cannot display value. No PropertyDrawer for (" + Target.Type + ") [" + Target.ToString() + "]";
-                GenericPropertyDrawer.DrawPropertyDrawer(Target.Type, _valueProperty, new GUIContent(content, content));
+                GenericPropertyDrawer.DrawPropertyDrawerLayout(Target.Type, _valueProperty, new GUIContent(content, content));
 
                 if (scope.changed)
                 {

--- a/Assets/SO Architecture/Editor/Inspectors/CollectionEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/CollectionEditor.cs
@@ -8,57 +8,86 @@ namespace ScriptableObjectArchitecture.Editor
     public class CollectionEditor : UnityEditor.Editor
     {
         private BaseCollection Target { get { return (BaseCollection)target; } }
-        private SerializedProperty DeveloperDescription { get { return serializedObject.FindProperty("DeveloperDescription"); } }
+        private SerializedProperty DeveloperDescriptionProperty
+        {
+            get { return serializedObject.FindProperty(DESCRIPTION_PROPERTY_NAME); }
+        }
+        private SerializedProperty CollectionItemsProperty
+        {
+            get { return serializedObject.FindProperty(LIST_PROPERTY_NAME);}
+        }
 
         private ReorderableList _reorderableList;
 
+        // UI
         private const bool DISABLE_ELEMENTS = false;
         private const bool ELEMENT_DRAGGABLE = true;
         private const bool LIST_DISPLAY_HEADER = true;
         private const bool LIST_DISPLAY_ADD_BUTTON = true;
         private const bool LIST_DISPLAY_REMOVE_BUTTON = true;
 
+        private const float ELEMENT_BOTTOM_PADDING = 2.5f;
+
+        private GUIContent _titleGUIContent;
+        private GUIContent _noPropertyDrawerWarningGUIContent;
+
+        private const string TITLE_FORMAT = "List ({0})";
+        private const string NO_PROPERTY_WARNING_FORMAT = "No PropertyDrawer for type [{0}]";
+
+        // Property Names
+        private const string LIST_PROPERTY_NAME = "_list";
+        private const string DESCRIPTION_PROPERTY_NAME = "DeveloperDescription";
+
         private void OnEnable()
         {
-            SerializedProperty items = serializedObject.FindProperty("_list");
+            _titleGUIContent = new GUIContent(string.Format(TITLE_FORMAT, Target.Type));
+            _noPropertyDrawerWarningGUIContent = new GUIContent(string.Format(NO_PROPERTY_WARNING_FORMAT, Target.Type));
 
-            string title = "List (" + Target.Type + ")";
-
-            _reorderableList = new ReorderableList(serializedObject, items, ELEMENT_DRAGGABLE, LIST_DISPLAY_HEADER, LIST_DISPLAY_ADD_BUTTON, LIST_DISPLAY_REMOVE_BUTTON);
-            _reorderableList.drawHeaderCallback += (Rect rect) => { EditorGUI.LabelField(rect, title); };
-            _reorderableList.drawElementCallback += DrawElement;
-            _reorderableList.onRemoveCallback += Remove;
-            _reorderableList.onChangedCallback += (ReorderableList list) => { Repaint(); };
+            _reorderableList = new ReorderableList(
+                serializedObject,
+                CollectionItemsProperty,
+                ELEMENT_DRAGGABLE,
+                LIST_DISPLAY_HEADER,
+                LIST_DISPLAY_ADD_BUTTON,
+                LIST_DISPLAY_REMOVE_BUTTON)
+            {
+                drawHeaderCallback = DrawHeader,
+                drawElementCallback = DrawElement,
+                elementHeightCallback = GetElementHeight,
+                onRemoveCallback = Remove
+            };
         }
         public override void OnInspectorGUI()
         {
-            serializedObject.Update();
+            EditorGUI.BeginChangeCheck();
 
             _reorderableList.DoLayoutList();
 
-            EditorGUILayout.PropertyField(DeveloperDescription);
+            EditorGUILayout.PropertyField(DeveloperDescriptionProperty);
 
-            serializedObject.ApplyModifiedProperties();
+            if (EditorGUI.EndChangeCheck())
+            {
+                serializedObject.ApplyModifiedProperties();
+            }
+        }
+        private void DrawHeader(Rect rect)
+        {
+            EditorGUI.LabelField(rect, _titleGUIContent);
         }
         private void DrawElement(Rect rect, int index, bool isActive, bool isFocused)
         {
-            rect.height = EditorGUIUtility.singleLineHeight;
-            rect.y++;
-
-            SerializedProperty property = _reorderableList.serializedProperty.GetArrayElementAtIndex(index);
+            SerializedProperty property = CollectionItemsProperty.GetArrayElementAtIndex(index);
 
             EditorGUI.BeginDisabledGroup(DISABLE_ELEMENTS);
 
-            EditorGUI.LabelField(rect, "Element " + index);
+            GenericPropertyDrawer.DrawPropertyDrawer(rect, Target.Type, property, _noPropertyDrawerWarningGUIContent);
 
-            rect.width /= 2;
-            rect.x += rect.width;
-
-            string content = "No PropertyDrawer for " + Target.Type;
-            GenericPropertyDrawer.DrawPropertyDrawer(Target.Type, property, new GUIContent(content, content));
-
-            //EditorGUI.ObjectField(rect, "Element " + index, property.objectReferenceValue, Target.Type, false);
             EditorGUI.EndDisabledGroup();
+        }
+        private float GetElementHeight(int index)
+        {
+            var indexedItemProperty = CollectionItemsProperty.GetArrayElementAtIndex(index);
+            return EditorGUI.GetPropertyHeight(indexedItemProperty) + ELEMENT_BOTTOM_PADDING;
         }
         private void Remove(ReorderableList list)
         {


### PR DESCRIPTION
### Summary
I've fixed a bug with the way `ReorderableList` elements were being drawn in `CollectionEditor`/`GenericPropertyDrawer` that should result in each item in the collection being rendered properly in the ReorderableList itself inline with their indexed position rather than directly below the list and in between the developer description. The chief thing to note here is that usage of ReorderableList is akin to a property drawer in that it does not respect GUILayout elements. 

**Before**
![image](https://user-images.githubusercontent.com/1663648/56417092-214e3980-6293-11e9-9ac9-15d20383a41a.png)

![image](https://user-images.githubusercontent.com/1663648/56417124-362acd00-6293-11e9-8824-00552ec357b1.png)

**After**
![image](https://user-images.githubusercontent.com/1663648/56416115-2eb5f480-6290-11e9-8390-83cf23d40c49.png)

![image](https://user-images.githubusercontent.com/1663648/56417165-59557c80-6293-11e9-8684-21b9a3f20881.png)

### Testing
I've created some test collection variables in an additional test commit to inspect and if there any custom types that would normally span a single line in height they should also work with this change. One of the results of this fix is that each element should be sized properly for the height of the property drawer rendering it.

### Changes
**Fixed issue with reorderable list elements**
* Renamed the existing method DrawPropertyDrawer to DrawPropertyDrawerLayout to indicate it used the native Unity auto-layout controls and created a new method using the older method name that uses the non-layout controls. Added method documentation to both explaining their usage.
* Changed BaseVariableEditor to use the new DrawPropertyDrawerLayout method name.
* Cleaned up CollectionEditor and removed several redundant calls to modify the rect, redundant callbacks, etc..
* Fixed a bug in CollectionEditor where the ReorderableList elements were being drawn by EditorGUILayout methods. These elements act similarly to PropertyDrawers in that they do not respect the auto-layout system methods and need to drawn using the non-layout methods that accept a Rect. I have added usage of callback `elementHeightCallback` so that the height of the element rect can vary depending on the generic T type element's property drawer and changed the element drawing logic to use a non-layout version of the same method from GenericPropertyDrawer. The end result is that these elements are now drawn inline with the reorderable list element instead of below the entire list.