### PR TITLE
Fix Unity structs drawn in property drawer

### DIFF
--- a/Assets/PR Test Content.meta
+++ b/Assets/PR Test Content.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 918bbf3c68c7e5a418c8cfe26c10b0b2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/QuaternionCollection.asset
+++ b/Assets/PR Test Content/QuaternionCollection.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 376c15839ad34eb4788c493b6b34c89d, type: 3}
+  m_Name: QuaternionCollection
+  m_EditorClassIdentifier: 
+  DeveloperDescription:
+    _value: 
+  _list:
+  - {x: 1.36, y: 0.84, z: 2.53, w: -1.62}
+  - {x: -0.75, y: 1.51, z: -1.21, w: 1.54}

--- a/Assets/PR Test Content/QuaternionCollection.asset.meta
+++ b/Assets/PR Test Content/QuaternionCollection.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fa65c2fab34f15d42adf3dfa7a4ea129
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/QuaternionVariable.asset
+++ b/Assets/PR Test Content/QuaternionVariable.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f722081b3e7717849b9b80bdafe2891c, type: 3}
+  m_Name: QuaternionVariable
+  m_EditorClassIdentifier: 
+  DeveloperDescription:
+    _value: 
+  _value: {x: 2.98, y: -1.26, z: 1.29, w: -2.07}
+  _readOnly: 0
+  _raiseWarning: 1

--- a/Assets/PR Test Content/QuaternionVariable.asset.meta
+++ b/Assets/PR Test Content/QuaternionVariable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 45233654c9c982f4fa4c56e532223938
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/UnityStructDrawerExample.cs
+++ b/Assets/PR Test Content/UnityStructDrawerExample.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace ScriptableObjectArchitecture
+{
+    public class UnityStructDrawerExample : MonoBehaviour
+    {
+        [SerializeField]
+        private Vector2Reference _vector2Reference;
+
+        [SerializeField]
+        private Vector3Reference _vector3Reference;
+
+        [SerializeField]
+        private Vector4Reference _vector4Reference;
+
+        [SerializeField]
+        private QuaternionReference quaternionReference;
+
+        [SerializeField]
+        private Vector2Reference[] _vector2References;
+
+        [SerializeField]
+        private Vector3Reference[] _vector3References;
+
+        [SerializeField]
+        private Vector4Reference[] _vector4References;
+
+        [SerializeField]
+        private QuaternionReference[] quaternionReferences;
+    }
+}

--- a/Assets/PR Test Content/UnityStructDrawerExample.cs.meta
+++ b/Assets/PR Test Content/UnityStructDrawerExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8547eb8e65f6f6347a0bc284bdddd6fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/UnityStructTestScene.unity
+++ b/Assets/PR Test Content/UnityStructTestScene.unity
@@ -1,0 +1,353 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1649640649
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1649640652}
+  - component: {fileID: 1649640651}
+  - component: {fileID: 1649640650}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1649640650
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649640649}
+  m_Enabled: 1
+--- !u!20 &1649640651
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649640649}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1649640652
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649640649}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2115062960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2115062962}
+  - component: {fileID: 2115062961}
+  - component: {fileID: 2115062963}
+  m_Layer: 0
+  m_Name: UnityStructDrawerExample
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &2115062961
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2115062960}
+  m_Enabled: 1
+  serializedVersion: 9
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &2115062962
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2115062960}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &2115062963
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2115062960}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8547eb8e65f6f6347a0bc284bdddd6fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _vector2Reference:
+    _useConstant: 1
+    _constantValue: {x: 0, y: 0}
+    _variable: {fileID: 0}
+  _vector3Reference:
+    _useConstant: 1
+    _constantValue: {x: 0, y: 0, z: 0}
+    _variable: {fileID: 0}
+  _vector4Reference:
+    _useConstant: 1
+    _constantValue: {x: 0, y: 0, z: 0, w: 0}
+    _variable: {fileID: 0}
+  quaternionReference:
+    _useConstant: 1
+    _constantValue: {x: 0, y: 0, z: 0, w: 0}
+    _variable: {fileID: 0}
+  _vector2References:
+  - _useConstant: 1
+    _constantValue: {x: 0, y: 0}
+    _variable: {fileID: 0}
+  - _useConstant: 0
+    _constantValue: {x: 0, y: 0}
+    _variable: {fileID: 0}
+  _vector3References:
+  - _useConstant: 1
+    _constantValue: {x: 0, y: 0, z: 0}
+    _variable: {fileID: 0}
+  - _useConstant: 0
+    _constantValue: {x: 0, y: 0, z: 0}
+    _variable: {fileID: 0}
+  _vector4References:
+  - _useConstant: 1
+    _constantValue: {x: 0, y: 0, z: 0, w: 0}
+    _variable: {fileID: 0}
+  - _useConstant: 0
+    _constantValue: {x: 0, y: 0, z: 0, w: 0}
+    _variable: {fileID: 0}
+  quaternionReferences:
+  - _useConstant: 1
+    _constantValue: {x: 0, y: 0, z: 0, w: 0}
+    _variable: {fileID: 0}
+  - _useConstant: 0
+    _constantValue: {x: 0, y: 0, z: 0, w: 0}
+    _variable: {fileID: 0}

--- a/Assets/PR Test Content/UnityStructTestScene.unity.meta
+++ b/Assets/PR Test Content/UnityStructTestScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e25486d181daecd4394267ada9627b06
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/Vector2Collection.asset
+++ b/Assets/PR Test Content/Vector2Collection.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d06ceb6f5b9494247a47b2b9639f1fa4, type: 3}
+  m_Name: Vector2Collection
+  m_EditorClassIdentifier: 
+  DeveloperDescription:
+    _value: 
+  _list:
+  - {x: 0, y: 0}
+  - {x: 0, y: 0}

--- a/Assets/PR Test Content/Vector2Collection.asset.meta
+++ b/Assets/PR Test Content/Vector2Collection.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27b914cbf2400164ab3b833b1824a392
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/Vector2Variable.asset
+++ b/Assets/PR Test Content/Vector2Variable.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d6a231661af38844caae4ded01abd631, type: 3}
+  m_Name: Vector2Variable
+  m_EditorClassIdentifier: 
+  DeveloperDescription:
+    _value: 
+  _value: {x: 0, y: 0}
+  _readOnly: 0
+  _raiseWarning: 1

--- a/Assets/PR Test Content/Vector2Variable.asset.meta
+++ b/Assets/PR Test Content/Vector2Variable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 32f707c3778f8e34b9538bafb6296960
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/Vector3Collection.asset
+++ b/Assets/PR Test Content/Vector3Collection.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a166c222ab884c40a383e3d630076e1, type: 3}
+  m_Name: Vector3Collection
+  m_EditorClassIdentifier: 
+  DeveloperDescription:
+    _value: 
+  _list:
+  - {x: 0, y: 0, z: 0}
+  - {x: 0, y: 0, z: 0}

--- a/Assets/PR Test Content/Vector3Collection.asset.meta
+++ b/Assets/PR Test Content/Vector3Collection.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59e52ca3a4472f84dbc94b8da39c6f4a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/Vector3Variable.asset
+++ b/Assets/PR Test Content/Vector3Variable.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 55a1fbeb783df41428d5464d443e2265, type: 3}
+  m_Name: Vector3Variable
+  m_EditorClassIdentifier: 
+  DeveloperDescription:
+    _value: 
+  _value: {x: 0, y: 0, z: 0}
+  _readOnly: 0
+  _raiseWarning: 1

--- a/Assets/PR Test Content/Vector3Variable.asset.meta
+++ b/Assets/PR Test Content/Vector3Variable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d467de41edba94458c7e597d5fd779f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/Vector4Collection.asset
+++ b/Assets/PR Test Content/Vector4Collection.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f851553b3485f64b882c79368923ca7, type: 3}
+  m_Name: Vector4Collection
+  m_EditorClassIdentifier: 
+  DeveloperDescription:
+    _value: 
+  _list:
+  - {x: 0, y: 0, z: 0, w: 0}
+  - {x: 0, y: 0, z: 0, w: 0}
+  - {x: 0, y: 0, z: 0, w: 0}

--- a/Assets/PR Test Content/Vector4Collection.asset.meta
+++ b/Assets/PR Test Content/Vector4Collection.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 534ffd156ad0bb849a3cadcfb8c9812c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PR Test Content/Vector4Variable.asset
+++ b/Assets/PR Test Content/Vector4Variable.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9aafcfecb82f81d4bba4abd0e634e0a5, type: 3}
+  m_Name: Vector4Variable
+  m_EditorClassIdentifier: 
+  DeveloperDescription:
+    _value: 
+  _value: {x: 0, y: 0, z: 0, w: 0}
+  _readOnly: 0
+  _raiseWarning: 1

--- a/Assets/PR Test Content/Vector4Variable.asset.meta
+++ b/Assets/PR Test Content/Vector4Variable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b2cc13cfe190d8458ea6d71e6b2819e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SO Architecture/Editor/Drawers/GenericPropertyDrawer.cs
+++ b/Assets/SO Architecture/Editor/Drawers/GenericPropertyDrawer.cs
@@ -1,15 +1,34 @@
-﻿using UnityEditor;
+﻿using System;
+using UnityEditor;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace ScriptableObjectArchitecture.Editor
 {
     public static class GenericPropertyDrawer
     {
+        private const string VALUE_LABEL = "Value";
+
+        private static GUIContent ValueGUIContent
+        {
+            get
+            {
+                if (_valueGUIContent == null)
+                {
+                    _valueGUIContent = new GUIContent(VALUE_LABEL);
+                }
+
+                return _valueGUIContent;
+            }
+        }
+
+        private static GUIContent _valueGUIContent;
+
         /// <summary>
         /// Draws a property drawer using the <see cref="EditorGUI"/> methods and the area the drawer is drawn
         /// in is determined by the passed <see cref="Rect"/> <paramref name="rect"/>.
         /// </summary>
-        public static void DrawPropertyDrawer(Rect rect, System.Type type, SerializedProperty property, GUIContent errorLabel)
+        public static void DrawPropertyDrawer(Rect rect, Type type, SerializedProperty property, GUIContent errorLabel)
         {
             if (SOArchitecture_EditorUtility.HasPropertyDrawer(type) || typeof(Object).IsAssignableFrom(type) || type.IsEnum)
             {
@@ -21,8 +40,27 @@ namespace ScriptableObjectArchitecture.Editor
                 {
                     using (new EditorGUI.DisabledGroupScope(true))
                     {
-                        EditorGUI.ObjectField(rect, new GUIContent("Value"), property.objectReferenceValue, type, false);
+                        EditorGUI.ObjectField(rect, ValueGUIContent, property.objectReferenceValue, type, false);
                     }
+                }
+                else if (type.IsAssignableFrom(typeof(Quaternion)))
+                {
+                    property.quaternionValue = EditorGUI.Vector4Field(
+                        rect,
+                        string.Empty,
+                        property.quaternionValue.ToVector4()).ToQuaternion();
+                }
+                else if (type.IsAssignableFrom(typeof(Vector4)))
+                {
+                    property.vector4Value = EditorGUI.Vector4Field(rect, string.Empty, property.vector4Value);
+                }
+                else if (type.IsAssignableFrom(typeof(Vector3)))
+                {
+                    property.vector3Value = EditorGUI.Vector3Field(rect, string.Empty, property.vector3Value);
+                }
+                else if (type.IsAssignableFrom(typeof(Vector2)))
+                {
+                    property.vector2Value = EditorGUI.Vector2Field(rect, string.Empty, property.vector2Value);
                 }
                 else
                 {
@@ -38,7 +76,7 @@ namespace ScriptableObjectArchitecture.Editor
         /// <summary>
         /// Draws a property drawer using the <see cref="EditorGUILayout"/> methods.
         /// </summary>
-        public static void DrawPropertyDrawerLayout(System.Type type, SerializedProperty property, GUIContent errorLabel)
+        public static void DrawPropertyDrawerLayout(Type type, SerializedProperty property, GUIContent errorLabel)
         {
             if (SOArchitecture_EditorUtility.HasPropertyDrawer(type) || typeof(Object).IsAssignableFrom(type) || type.IsEnum)
             {
@@ -50,8 +88,26 @@ namespace ScriptableObjectArchitecture.Editor
                 {
                     using (new EditorGUI.DisabledGroupScope(true))
                     {
-                        EditorGUILayout.ObjectField(new GUIContent("Value"), property.objectReferenceValue, type, false);
+                        EditorGUILayout.ObjectField(ValueGUIContent, property.objectReferenceValue, type, false);
                     }
+                }
+                else if (type.IsAssignableFrom(typeof(Quaternion)))
+                {
+                    property.quaternionValue = EditorGUILayout.Vector4Field(
+                        string.Empty,
+                        property.quaternionValue.ToVector4()).ToQuaternion();
+                }
+                else if (type.IsAssignableFrom(typeof(Vector4)))
+                {
+                    property.vector4Value = EditorGUILayout.Vector4Field(string.Empty, property.vector4Value);
+                }
+                else if (type.IsAssignableFrom(typeof(Vector3)))
+                {
+                    property.vector3Value = EditorGUILayout.Vector3Field(string.Empty, property.vector3Value);
+                }
+                else if (type.IsAssignableFrom(typeof(Vector2)))
+                {
+                    property.vector2Value = EditorGUILayout.Vector2Field(string.Empty, property.vector2Value);
                 }
                 else
                 {
@@ -62,6 +118,19 @@ namespace ScriptableObjectArchitecture.Editor
             {
                 EditorGUILayout.LabelField(errorLabel);
             }
+        }
+
+        /// <summary>
+        /// Returns true if the passed <see cref="Type"/> <paramref name="type"/> should be displayed on
+        /// single line regardless of whether <see cref="EditorGUI.GetPropertyHeight(SerializedProperty)"/>
+        /// says otherwise.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static bool IsSingleLineGUIType(Type type)
+        {
+            return type.IsAssignableFrom(typeof(Vector4)) ||
+                   type.IsAssignableFrom(typeof(Quaternion));
         }
     }
 }

--- a/Assets/SO Architecture/Editor/Inspectors/CollectionEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/CollectionEditor.cs
@@ -88,7 +88,9 @@ namespace ScriptableObjectArchitecture.Editor
         private float GetElementHeight(int index)
         {
             var indexedItemProperty = CollectionItemsProperty.GetArrayElementAtIndex(index);
-            return EditorGUI.GetPropertyHeight(indexedItemProperty) + ELEMENT_BOTTOM_PADDING;
+            return GenericPropertyDrawer.IsSingleLineGUIType(Target.Type)
+                ? EditorGUIUtility.singleLineHeight + ELEMENT_BOTTOM_PADDING
+                : EditorGUI.GetPropertyHeight(indexedItemProperty) + ELEMENT_BOTTOM_PADDING;
         }
         private void Remove(ReorderableList list)
         {

--- a/Assets/SO Architecture/Editor/Inspectors/CollectionEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/CollectionEditor.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEditor;
 using UnityEngine;
-using ReorderableList = UnityEditorInternal.ReorderableList;
+using UnityEditorInternal;
 
 namespace ScriptableObjectArchitecture.Editor
 {
@@ -25,8 +25,6 @@ namespace ScriptableObjectArchitecture.Editor
         private const bool LIST_DISPLAY_HEADER = true;
         private const bool LIST_DISPLAY_ADD_BUTTON = true;
         private const bool LIST_DISPLAY_REMOVE_BUTTON = true;
-
-        private const float ELEMENT_BOTTOM_PADDING = 2.5f;
 
         private GUIContent _titleGUIContent;
         private GUIContent _noPropertyDrawerWarningGUIContent;
@@ -80,17 +78,22 @@ namespace ScriptableObjectArchitecture.Editor
 
             EditorGUI.BeginDisabledGroup(DISABLE_ELEMENTS);
 
-            rect.height = EditorGUIUtility.singleLineHeight;
             GenericPropertyDrawer.DrawPropertyDrawer(rect, Target.Type, property, _noPropertyDrawerWarningGUIContent);
 
             EditorGUI.EndDisabledGroup();
         }
+
+        /// <summary>
+        /// Return the height of the item in the <see cref="ReorderableList"/> that is being drawn.
+        /// </summary>
+        /// <param name="index">The index of the item in the list being drawn.</param>
+        /// <returns></returns>
         private float GetElementHeight(int index)
         {
             var indexedItemProperty = CollectionItemsProperty.GetArrayElementAtIndex(index);
             return GenericPropertyDrawer.IsSingleLineGUIType(Target.Type)
-                ? EditorGUIUtility.singleLineHeight + ELEMENT_BOTTOM_PADDING
-                : EditorGUI.GetPropertyHeight(indexedItemProperty) + ELEMENT_BOTTOM_PADDING;
+                ? EditorGUIUtility.singleLineHeight
+                : EditorGUI.GetPropertyHeight(indexedItemProperty);
         }
         private void Remove(ReorderableList list)
         {

--- a/Assets/SO Architecture/Extensions.meta
+++ b/Assets/SO Architecture/Extensions.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4d23a1b5eda94e5484e3e8835e3c754d
+timeCreated: 1555707444

--- a/Assets/SO Architecture/Extensions/QuaternionExtensions.cs
+++ b/Assets/SO Architecture/Extensions/QuaternionExtensions.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
+{
+    /// <summary>
+    /// Internal extension methods for <see cref="Quaternion"/>.
+    /// </summary>
+    internal static class QuaternionExtensions
+    {
+        /// <summary>
+        /// Returns a <see cref="Vector4"/> instance where the component values are equal to this
+        /// <see cref="Quaternion"/>'s components.
+        /// </summary>
+        /// <param name="quaternion"></param>
+        /// <returns></returns>
+        public static Vector4 ToVector4(this Quaternion quaternion)
+        {
+            return new Vector4(quaternion.x, quaternion.y, quaternion.z, quaternion.w);
+        }
+    }
+}

--- a/Assets/SO Architecture/Extensions/QuaternionExtensions.cs.meta
+++ b/Assets/SO Architecture/Extensions/QuaternionExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 519b10e3cd564520adb5118a5b996f43
+timeCreated: 1555707619

--- a/Assets/SO Architecture/Extensions/Vector4Extensions.cs
+++ b/Assets/SO Architecture/Extensions/Vector4Extensions.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+
+namespace ScriptableObjectArchitecture
+{
+    /// <summary>
+    /// Internal extension methods for <see cref="Vector4"/>.
+    /// </summary>
+    internal static class Vector4Extensions
+    {
+        /// <summary>
+        /// Returns a <see cref="Quaternion"/> instance where the component values are equal to this
+        /// <see cref="Vector4"/>'s components.
+        /// </summary>
+        /// <param name="vector4"></param>
+        /// <returns></returns>
+        public static Quaternion ToQuaternion(this Vector4 vector4)
+        {
+            return new Quaternion(vector4.x, vector4.y, vector4.z, vector4.w);
+        }
+    }
+}

--- a/Assets/SO Architecture/Extensions/Vector4Extensions.cs.meta
+++ b/Assets/SO Architecture/Extensions/Vector4Extensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f82581906385ab740af135269a99379d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -5,7 +5,10 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 0
-    path: 
-    guid: 00000000000000000000000000000000
+  - enabled: 1
+    path: Assets/PR Test Content/SceneVariableTestScene01.unity
+    guid: 100aa01d425663b4da3e0be46274f307
+  - enabled: 1
+    path: Assets/PR Test Content/SceneVariableTestScene02.unity
+    guid: 96e19de034d930845b2a4755ec9127c2
   m_configObjects: {}


### PR DESCRIPTION
### Summary
This PR resolves the issues discussed in https://github.com/DanielEverland/ScriptableObject-Architecture/issues/66 where certain Unity structs cannot be shown well via a catch-all property field. This PR resolves that by adding specific checks for those types and displays them how they are edited normally elsewhere in the editor.

### Testing
I've created a test script and scene at `Assets/PR Test Content/UnityStructTestScene.unity` where References can be viewed for each of the affected types as well as Variables/Collection assets for those same types in that folder. Try the inspector for each of these and switch them from constant to variable and back in the case of References.

### Changes
**Removed redundant call to set rect height**
* Removed redundant call to set rect height as it the height for an element in a reorderable list is set by its `elementHeightCallback`, which in this case is `GetElementHeight`. Removed padding `GetElementHeight` so that a single line item does not appear stretched.

**Modified collection, reference editors**
* Modified GenericPropertyDrawer to include edge case checks for both layout and non layout modes when the type of value being displayed is a Vector2/3/4 and Quaternion so that they can be displayed in the proper format for Variables, Collections, and References.
* Modified the CollectionEditor to include an edge case for Vector4, Quaternion to display them on a single line rather than use the reported property height which covers several lines.
* Modified BaseReferenceDrawer to draw constant values using GenericPropertyDrawer methods; this has the benefit of keeping existing functionality for constants, plus covering edge cases for Vector2/3/4 and Quaternions.

**Added internal extension methods for Vector4, Quaternion**
* Added conversion extension methods for Vector4, Quaternion to each other.