### PR TITLE
Created debug GUIStyle, refactoring

### DIFF
--- a/Assets/SO Architecture/Editor/Drawers/BaseReferenceDrawer.cs
+++ b/Assets/SO Architecture/Editor/Drawers/BaseReferenceDrawer.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
@@ -87,15 +88,10 @@ namespace ScriptableObjectArchitecture.Editor
 
             if (useConstant.boolValue)
             {
-                var drawSerializedProperty = useConstant.boolValue ? constantValue : variable;
-                var referenceObject = SerializedPropertyHelper.GetParent(drawSerializedProperty);
-                var valueFieldInfo = referenceObject.GetType().GetField(
-                    CONSTANT_VALUE_PROPERTY_NAME,
-                    BindingFlags.Instance | BindingFlags.NonPublic);
-                if (valueFieldInfo != null)
+                var genericReferenceType = GetReferenceGenericType(constantValue);
+                if (genericReferenceType != null)
                 {
-                    var targetType = valueFieldInfo.FieldType;
-                    GenericPropertyDrawer.DrawPropertyDrawer(refValuePosition, targetType, constantValue, GUIContent.none);
+                    GenericPropertyDrawer.DrawPropertyDrawer(refValuePosition, genericReferenceType, constantValue, GUIContent.none);
                 }
                 else
                 {
@@ -103,7 +99,7 @@ namespace ScriptableObjectArchitecture.Editor
                         property.objectReferenceValue,
                         COULD_NOT_FIND_VALUE_FIELD_WARNING_FORMAT,
                         CONSTANT_VALUE_PROPERTY_NAME,
-                        referenceObject.GetType());
+                        GetReferenceType(constantValue));
                 }
             }
             else
@@ -124,6 +120,21 @@ namespace ScriptableObjectArchitecture.Editor
             return !useConstant.boolValue || constantPropertyHeight <= EditorGUIUtility.singleLineHeight
                 ? EditorGUIUtility.singleLineHeight
                 : EditorGUIUtility.singleLineHeight * 2 + constantPropertyHeight;
+        }
+
+        public Type GetReferenceType(SerializedProperty property)
+        {
+            return SerializedPropertyHelper.GetParent(property).GetType();
+        }
+
+        public Type GetReferenceGenericType(SerializedProperty property)
+        {
+            var referenceObject = SerializedPropertyHelper.GetParent(property);
+            var valueFieldInfo = referenceObject.GetType().GetField(
+                CONSTANT_VALUE_PROPERTY_NAME,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            return valueFieldInfo == null ? null : valueFieldInfo.FieldType;
         }
     }
 }

--- a/Assets/SO Architecture/Editor/SOArchitecture_EditorUtility.cs
+++ b/Assets/SO Architecture/Editor/SOArchitecture_EditorUtility.cs
@@ -15,6 +15,28 @@ namespace ScriptableObjectArchitecture.Editor
             _defaultTargetType = typeof(SOArchitecture_EditorUtility).Assembly;
         }
 
+        /// <summary>
+        /// A debug <see cref="GUIStyle"/> that allows for identification of EditorGUI Rect issues.
+        /// </summary>
+        public static GUIStyle DebugStyle
+        {
+            get
+            {
+                if (_debugStyle == null)
+                {
+                    var debugColor = Color.magenta;
+                    debugColor.a = 0.33f;
+
+                    _debugStyle = new GUIStyle(GUI.skin.box);
+                    _debugStyle.normal.background = MakeTex(2, 2, debugColor);
+                }
+
+                return _debugStyle;
+            }
+        }
+
+        private static GUIStyle _debugStyle;
+
         private static PropertyDrawerGraph _propertyDrawerGraph;
         private static Assembly _defaultTargetType;
         private static BindingFlags _fieldBindingsFlag = BindingFlags.Instance | BindingFlags.NonPublic;
@@ -50,6 +72,18 @@ namespace ScriptableObjectArchitecture.Editor
         private static void OnProjectReloaded()
         {
             _propertyDrawerGraph = null;
+        }
+        private static Texture2D MakeTex(int width, int height, Color col)
+        {
+            Color[] pix = new Color[width * height];
+            for (int i = 0; i < pix.Length; ++i)
+            {
+                pix[i] = col;
+            }
+            Texture2D result = new Texture2D(width, height);
+            result.SetPixels(pix);
+            result.Apply();
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
### Summary
This PR does some slight refactoring of BaseReferenceDrawer with no functional changes (improves readability) and adds a debug GUIStyle to make it easier to troubleshoot EditorGUI issues in the future.

### Testing
This PR contains no functional changes; everything should be working as it did before.

### Changes
**Created debug GUIStyle, refactoring**
* Created a debug GUIStyle named `DebugStyle` that allows for drawing the background of a GUI element as a 1/3 alpha pink box. This allows for easier debugging of GUI drawn elements in the editor.
* Refactored BaseReferenceDrawer logic into helper methods.