### PR TITLE
Fixed a bug with CollectionEditor

### DIFF
--- a/Assets/SO Architecture/Editor/Inspectors/CollectionEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/CollectionEditor.cs
@@ -51,8 +51,7 @@ namespace ScriptableObjectArchitecture.Editor
             {
                 drawHeaderCallback = DrawHeader,
                 drawElementCallback = DrawElement,
-                elementHeightCallback = GetElementHeight,
-                onRemoveCallback = Remove
+                elementHeightCallback = GetElementHeight
             };
         }
         public override void OnInspectorGUI()
@@ -94,10 +93,6 @@ namespace ScriptableObjectArchitecture.Editor
             return GenericPropertyDrawer.IsSingleLineGUIType(Target.Type)
                 ? EditorGUIUtility.singleLineHeight
                 : EditorGUI.GetPropertyHeight(indexedItemProperty);
-        }
-        private void Remove(ReorderableList list)
-        {
-            Target.List.RemoveAt(list.index);
         }
     }
 }


### PR DESCRIPTION
### Summary
This PR fixes a bug with the collection editor where the implementation for the `onRemoveCallback` of the `ReorderableList` being used would result in an exception every time a user tried to remove an item. The fix actually removes both the implementation and use of the callback as the default implementation internal to `ReorderableList` will have the same net result as the implementation was trying to do.

![image](https://user-images.githubusercontent.com/1663648/57057733-5acb6f80-6cab-11e9-9a96-64f4b6502a15.png)

### Testing
Attempt to add and remove entries from any Collection asset. Prior to this fix you would see the exception thrown above and the item would not be shown as removed in the inspector. With this fix you should see the item removed in the inspector without any error.

### Changes
**Fixed a bug with CollectionEditor**
* Removed the implementation for the onRemoveCallback used by the ReorderableList in the CollectionEditor; this keeps the intended behavior (as default) for removing the item, but prevents an exception that a user would experience by removing an item this way.
* Missing meta file