### PR TITLE
Added AudioClip Events and Listener

### DIFF
--- a/Assets/SO Architecture/Events/Game Events/AudioClipGameEvent.cs
+++ b/Assets/SO Architecture/Events/Game Events/AudioClipGameEvent.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace ScriptableObjectArchitecture
+{
+    [System.Serializable]
+    [CreateAssetMenu(
+        fileName = "AudioClipGameEvent.asset",
+        menuName = SOArchitecture_Utility.ADVANCED_GAME_EVENT + "AudioClip",
+        order = SOArchitecture_Utility.ASSET_MENU_ORDER_EVENTS + 5)]
+    public sealed class AudioClipGameEvent : GameEventBase<AudioClip>
+    {
+
+    }
+}

--- a/Assets/SO Architecture/Events/Game Events/AudioClipGameEvent.cs.meta
+++ b/Assets/SO Architecture/Events/Game Events/AudioClipGameEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 96c62cae1d494005aee595768eefb7ae
+timeCreated: 1572335463

--- a/Assets/SO Architecture/Events/Listeners/AudioClipGameEventListener.cs
+++ b/Assets/SO Architecture/Events/Listeners/AudioClipGameEventListener.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace ScriptableObjectArchitecture
+{
+    [AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "AudioClip Event Listener")]
+    public sealed class AudioClipGameEventListener : BaseGameEventListener<AudioClip, AudioClipGameEvent, AudioClipUnityEvent>
+    {
+
+    }
+}

--- a/Assets/SO Architecture/Events/Listeners/AudioClipGameEventListener.cs.meta
+++ b/Assets/SO Architecture/Events/Listeners/AudioClipGameEventListener.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1b59f62474a8441eb57693365ea24e83
+timeCreated: 1572335595

--- a/Assets/SO Architecture/Events/Responses/AudioClipUnityEvent.cs
+++ b/Assets/SO Architecture/Events/Responses/AudioClipUnityEvent.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace ScriptableObjectArchitecture
+{
+    [System.Serializable]
+    public sealed class AudioClipUnityEvent : UnityEvent<AudioClip>
+    {
+
+    }
+}

--- a/Assets/SO Architecture/Events/Responses/AudioClipUnityEvent.cs.meta
+++ b/Assets/SO Architecture/Events/Responses/AudioClipUnityEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7dfc7e5eb87c48ffbd1ea05999025055
+timeCreated: 1572335662

--- a/Assets/SO Architecture/Variables/SceneVariable.cs
+++ b/Assets/SO Architecture/Variables/SceneVariable.cs
@@ -77,6 +77,8 @@ namespace ScriptableObjectArchitecture
         }
         #endif
 
+        #pragma warning disable 0649
+
         [SerializeField]
         private string _sceneName;
 
@@ -85,6 +87,8 @@ namespace ScriptableObjectArchitecture
 
         [SerializeField]
         private bool _isSceneEnabled;
+
+        #pragma warning restore 0649
 
         public SceneInfo()
         {


### PR DESCRIPTION
## Summary
Over the last few game jams, I've used a one-off audio playing system each time which listened to an AudioClip GameEvent to allow other systems to be able to play audio in a decoupled way. I've done it enough to where I believe this would be a viable, generally useful addition to the core ScriptableArchitecture library. For this I've created the following:
* AudioClipGameEvent
* AudioClipUnityEvent
* AudioClipGameEventListener

I did not add any icons to the scripts listed above, but that would also be a good thing to do before this is merged in.

In addition, I've hidden a warning via #pragma in the console that appears for private serialized fields in SceneVariable that is a false positive.