### PR TITLE
Created variable, reference for LayerMask

### DIFF
--- a/Assets/SO Architecture/References/LayerMaskReference.cs
+++ b/Assets/SO Architecture/References/LayerMaskReference.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace ScriptableObjectArchitecture
+{
+	[System.Serializable]
+	public sealed class LayerMaskReference : BaseReference<LayerMask, LayerMaskVariable>
+	{
+	    public LayerMaskReference() : base() { }
+	    public LayerMaskReference(LayerMask value) : base(value) { }
+	}
+}

--- a/Assets/SO Architecture/References/LayerMaskReference.cs.meta
+++ b/Assets/SO Architecture/References/LayerMaskReference.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e390a6289e5530c4d8f4d38ccdbfcc5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SO Architecture/Variables/LayerMaskVariable.cs
+++ b/Assets/SO Architecture/Variables/LayerMaskVariable.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace ScriptableObjectArchitecture
+{
+	[CreateAssetMenu(
+	    fileName = "LayerMaskVariable.asset",
+	    menuName = SOArchitecture_Utility.ADVANCED_VARIABLE_SUBMENU + "LayerMask",
+	    order = 120)]
+	public class LayerMaskVariable : BaseVariable<LayerMask>
+	{
+	}
+}

--- a/Assets/SO Architecture/Variables/LayerMaskVariable.cs.meta
+++ b/Assets/SO Architecture/Variables/LayerMaskVariable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b26aa8462eb624458ecacd922a870e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

This PR adds a `LayerMaskVariable` and `LayerMaskReference` type. A `LayerMask` is a native Unity type used to filter objects for collision detection to specific layers specified in the Flag value. It's useful to be able to encapsulate this value as an asset and share it between multiple things to that they can detect collisions against the same layers and be able to change that value in one place.

![image](https://user-images.githubusercontent.com/1663648/71155679-8b621880-223e-11ea-98f5-25c736396f8d.png)


I did not create an icon for this type, but if you could that would be great!

## Testing

Create a `LayerMaskVariable` asset and make sure that it serializes the value. Other than that, testing should be pretty minimal.


