### PR TITLE
Fixed bug in TypedGameEventEditor

### DIFF
--- a/Assets/SO Architecture/Editor/Inspectors/TypedGameEventEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/TypedGameEventEditor.cs
@@ -20,7 +20,15 @@ namespace ScriptableObjectArchitecture.Editor
         {
             SerializedProperty property = serializedObject.FindProperty("_debugValue");
 
-            EditorGUILayout.PropertyField(property);
+            using (var scope = new EditorGUI.ChangeCheckScope())
+            {
+                EditorGUILayout.PropertyField(property);
+
+                if (scope.changed)
+                {
+                    serializedObject.ApplyModifiedProperties();
+                }
+            }
 
             if (GUILayout.Button("Raise"))
             {


### PR DESCRIPTION
##Summary
Fixed a bug in the `TypedGameEventEditor` where a property change for its serialized type would not apply those changes to the serialized object. This would result in the value never being applied to that derived type of GameEventBase<T>. We discovered this when creating a `GameEventBase<T>` where `T` was an Enum and the selecting a different value than the default would not be set.

Unity 2019.3.0f6

## Testing
Create an Enum-derived type such as the example below and create a GameEventBase class instance of it. In this example, One would be the default value set and toggling the value of the event in the inspector to something different should apply.

```
public enum FooType
{
    One,
    Two,
    Three
}
