### PR TITLE
Add namespace support + some basic checks

### DIFF
--- a/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerationWindow.cs
+++ b/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerationWindow.cs
@@ -122,16 +122,16 @@ namespace ScriptableObjectArchitecture.Editor
             EditorGUILayout.LabelField("Information", EditorStyles.boldLabel);
 
             // Type name.
+            _typeName = EditorGUILayout.TextField(new GUIContent("Type Name", "Case sensitive, ensure exact match with actual type name"), _typeName);
+
             if (string.IsNullOrEmpty(_typeName))
                 EditorGUILayout.HelpBox("Please fill out the Type Name", MessageType.Error);
 
-            _typeName = EditorGUILayout.TextField(new GUIContent("Type Name", "Case sensitive, ensure exact match with actual type name"), _typeName);
+            // Namespace
+            _namespace = EditorGUILayout.TextField(new GUIContent("Namespace", "Case sensitive, ensure exact match with actual namespace"), _namespace);
 
             if (string.IsNullOrEmpty(_namespace))
                 EditorGUILayout.HelpBox("Please fill out the Namespace", MessageType.Error);
-
-            // Namespace
-            _namespace = EditorGUILayout.TextField(new GUIContent("Namespace", "Case sensitive, ensure exact match with actual namespace"), _namespace);
 
             // Menu name.
             _menuAnim.target = RequiresMenu();

--- a/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerationWindow.cs
+++ b/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerationWindow.cs
@@ -79,6 +79,9 @@ namespace ScriptableObjectArchitecture.Editor
 
             DataFields();
 
+            if (string.IsNullOrEmpty(_typeName) || string.IsNullOrEmpty(_namespace))
+                GUI.enabled = false;
+
             if (GUILayout.Button("Generate"))
             {
                 SO_CodeGenerator.Data data = new SO_CodeGenerator.Data()

--- a/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerationWindow.cs
+++ b/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerationWindow.cs
@@ -52,6 +52,7 @@ namespace ScriptableObjectArchitecture.Editor
         private int _order;
         private string _typeName;
         private string _menuName;
+        private string _namespace;
         private AnimBool _menuAnim;
         private AnimBool _clampedValueHelpBoxAnim;
 
@@ -85,6 +86,7 @@ namespace ScriptableObjectArchitecture.Editor
                     Types = _states,
                     TypeName = _typeName,
                     MenuName = RequiresMenu() ? _menuName : default(string),
+                    Namespace = _namespace,
                     Order = _order,
                 };
 
@@ -117,7 +119,16 @@ namespace ScriptableObjectArchitecture.Editor
             EditorGUILayout.LabelField("Information", EditorStyles.boldLabel);
 
             // Type name.
+            if (string.IsNullOrEmpty(_typeName))
+                EditorGUILayout.HelpBox("Please fill out the Type Name", MessageType.Error);
+
             _typeName = EditorGUILayout.TextField(new GUIContent("Type Name", "Case sensitive, ensure exact match with actual type name"), _typeName);
+
+            if (string.IsNullOrEmpty(_namespace))
+                EditorGUILayout.HelpBox("Please fill out the Namespace", MessageType.Error);
+
+            // Namespace
+            _namespace = EditorGUILayout.TextField(new GUIContent("Namespace", "Case sensitive, ensure exact match with actual namespace"), _namespace);
 
             // Menu name.
             _menuAnim.target = RequiresMenu();

--- a/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerator.cs
+++ b/Assets/SO Architecture/Editor/Code Generation/SO_CodeGenerator.cs
@@ -70,6 +70,7 @@ namespace ScriptableObjectArchitecture.Editor
             public bool[] Types;
             public string TypeName;
             public string MenuName;
+            public string Namespace;
             public int Order;
         }
 
@@ -101,12 +102,13 @@ namespace ScriptableObjectArchitecture.Editor
 
         public static void Generate(Data data)
         {
-            _replacementStrings = new string[4, 2]
+            _replacementStrings = new string[5, 2]
             {
             { "$TYPE$", data.TypeName },
             { "$TYPE_NAME$", CapitalizeFirstLetter(data.TypeName) },
             { "$MENU_NAME$", data.MenuName },
             { "$ORDER$", data.Order.ToString() },
+            { "$NAMESPACE$", data.Namespace}
             };
 
             for (int i = 0; i < TYPE_COUNT; i++)

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/CollectionTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/CollectionTemplate
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
+using ScriptableObjectArchitecture;
 
-namespace ScriptableObjectArchitecture
+namespace $NAMESPACE$
 {
 	[CreateAssetMenu(
 	    fileName = "$TYPE_NAME$Collection.asset",

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventListenerTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventListenerTemplate
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
+using ScriptableObjectArchitecture;
 
-namespace ScriptableObjectArchitecture
+namespace $NAMESPACE$
 {
 	[AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "$TYPE$")]
 	public sealed class $TYPE_NAME$GameEventListener : BaseGameEventListener<$TYPE$, $TYPE_NAME$GameEvent, $TYPE_NAME$UnityEvent>

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventTemplate
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
+using ScriptableObjectArchitecture;
 
-namespace ScriptableObjectArchitecture
+namespace $NAMESPACE$
 {
 	[System.Serializable]
 	[CreateAssetMenu(

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/ReferenceTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/ReferenceTemplate
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
+using ScriptableObjectArchitecture;
 
-namespace ScriptableObjectArchitecture
+namespace $NAMESPACE$
 {
 	[System.Serializable]
 	public sealed class $TYPE_NAME$Reference : BaseReference<$TYPE$, $TYPE_NAME$Variable>

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/UnityEventTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/UnityEventTemplate
@@ -1,7 +1,8 @@
 ﻿using UnityEngine;
 using UnityEngine.Events;
+using ScriptableObjectArchitecture;
 
-namespace ScriptableObjectArchitecture
+namespace $NAMESPACE$
 {
 	[System.Serializable]
 	public sealed class $TYPE_NAME$UnityEvent : UnityEvent<$TYPE$>

--- a/Assets/SO Architecture/Editor/Code Generation/Templates/VariableTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/VariableTemplate
@@ -1,7 +1,8 @@
 ﻿using UnityEngine;
 using UnityEngine.Events;
+using ScriptableObjectArchitecture;
 
-namespace ScriptableObjectArchitecture
+namespace $NAMESPACE$
 {
 	[System.Serializable]
 	public class $TYPE_NAME$Event : UnityEvent<$TYPE_NAME$> { }


### PR DESCRIPTION
**Summary**

Solves #128 .

Some basic checks are also to ensure the type name and namespace are filled before generating the code. It doesn't prevent wrong inputs though, at the moment. That... might need a check into the types of each assemblies which is an expensive operation to do.

Edit: Sorry, referenced the wrong issue at first.