### PR TITLE
Fix BaseVariable using old value when raising event

### DIFF
--- a/Assets/SO Architecture/Editor/Inspectors/BaseVariableEditor.cs
+++ b/Assets/SO Architecture/Editor/Inspectors/BaseVariableEditor.cs
@@ -75,7 +75,7 @@ namespace ScriptableObjectArchitecture.Editor
         }
         protected void DrawReadonlyField()
         {
-            if (IsClampable)
+            if (_isClamped.boolValue)
                 return;
 
             EditorGUILayout.PropertyField(_readOnly, new GUIContent("Read Only", READONLY_TOOLTIP));

--- a/Assets/SO Architecture/Variables/BaseVariable.cs
+++ b/Assets/SO Architecture/Variables/BaseVariable.cs
@@ -100,10 +100,11 @@ namespace ScriptableObjectArchitecture
                 newValue = ClampValue(newValue);
             }
 
+            _value = newValue;
+
             if (!AreValuesEqual(newValue, _oldValue))
                 Raise();
 
-            _value = newValue;
             _oldValue = _value;
 
             return newValue;


### PR DESCRIPTION
When changing a variable in code, the raised event still has the old value. Assigning the newValue before raising the event solves the issue.

By the way, thanks a lot for this awesome framework!