### PR TITLE
Fix BaseVariable using old value when raising event

### DIFF
--- a/Assets/SO Architecture/Variables/BaseVariable.cs
+++ b/Assets/SO Architecture/Variables/BaseVariable.cs
@@ -100,10 +100,11 @@ namespace ScriptableObjectArchitecture
                 newValue = ClampValue(newValue);
             }
 
+            _value = newValue;
+
             if (!AreValuesEqual(newValue, _oldValue))
                 Raise();
 
-            _value = newValue;
             _oldValue = _value;
 
             return newValue;


### PR DESCRIPTION
When changing a variable in code, the raised event still has the old value. Assigning the newValue before raising the event solves the issue.

By the way, thanks a lot for this awesome framework!