### PR TITLE
Fix null pointer in BaseVariable.AreValuesEqual

### DIFF
--- a/Assets/SO Architecture/Variables/BaseVariable.cs
+++ b/Assets/SO Architecture/Variables/BaseVariable.cs
@@ -110,7 +110,9 @@ namespace ScriptableObjectArchitecture
         }
         protected virtual bool AreValuesEqual(T a, T b)
         {
-            return a.Equals(b);
+            if (a != null) return a.Equals(b);
+
+            return b == null;
         }
         protected virtual T ClampValue(T value)
         {


### PR DESCRIPTION
I created Custom Variable Types and got a null pointer exception when their initial values were null. This commit fixes that