### PR TITLE
Fix SceneIndex different from index in build settings which can cause exceptions when using LoadScene(int)

### DIFF
--- a/Assets/SO Architecture/Variables/SceneVariable.cs
+++ b/Assets/SO Architecture/Variables/SceneVariable.cs
@@ -111,13 +111,20 @@ namespace ScriptableObjectArchitecture
                 var scenes = UnityEditor.EditorBuildSettings.scenes;
 
                 SceneIndex = -1;
+                int enabledSceneIndex = 0;//scenes are only given a build index if enabled.
                 for (var i = 0; i < scenes.Length; i++)
                 {
+                    bool sceneIsEnabled = scenes[i].enabled;
                     if (scenes[i].guid.ToString() == sceneAssetGUID)
                     {
-                        SceneIndex = i;
-                        IsSceneEnabled = scenes[i].enabled;
+                        if(sceneIsEnabled)
+                            SceneIndex = enabledSceneIndex++;
+                        IsSceneEnabled = sceneIsEnabled;
                         break;
+                    }
+                    else if (sceneIsEnabled)
+                    {
+                        ++enabledSceneIndex;
                     }
                 }
             }


### PR DESCRIPTION
If a scene was index 3 visibly in the build index, but a scene above it was disabled, then the index shown in the SceneVariable would be off by 1 and cause problems when loading by integer.