### PR TITLE
Fixed event listener template naming issue

### DIFF
--- a/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventListenerTemplate
+++ b/Assets/SO Architecture/Editor/Code Generation/Templates/GameEventListenerTemplate
@@ -3,7 +3,7 @@ using ScriptableObjectArchitecture;
 
 namespace $NAMESPACE$
 {
-	[AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "$TYPE$")]
+	[AddComponentMenu(SOArchitecture_Utility.EVENT_LISTENER_SUBMENU + "$TYPE$" + " Event Listener")]
 	public sealed class $TYPE_NAME$GameEventListener : BaseGameEventListener<$TYPE$, $TYPE_NAME$GameEvent, $TYPE_NAME$UnityEvent>
 	{
 	}


### PR DESCRIPTION
fixes an issue with code generation where generated Event Listeners didn't actually say "Event Listener" in the AddComponentMenu, so they wouldn't show up when searching through all Event Listeners.